### PR TITLE
The plugin has to be enabled before it can be used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ Run `install.sh` or copy `OpenContainingFolder.plugin` and
 
 ## Usage
 
-Right click a track and select *Open containing folder*.
+ 1. Enable the plugin in Tools/Plugins.
+ 2. Right click a track and select *Open containing folder*.
 


### PR DESCRIPTION
This is just a documentation change for new users like me who were stumped as to why the plugin was seemingly not working after installation. The plugin does work under Rhythmbox 3.3.